### PR TITLE
fix: adapter hasstableids

### DIFF
--- a/tangram/src/main/java/com/tmall/wireless/tangram/dataparser/concrete/PojoGroupBasicAdapter.java
+++ b/tangram/src/main/java/com/tmall/wireless/tangram/dataparser/concrete/PojoGroupBasicAdapter.java
@@ -84,7 +84,8 @@ public class PojoGroupBasicAdapter extends GroupBasicAdapter<Card, BaseCell> {
         super(context, layoutManager, componentBinderResolver, cardBinderResolver);
         this.mMvHelper = mvHelper;
         this.mViewManager = viewManager;
-        setHasStableIds(true);
+        //if true, this adapter's items have stable IDs, but BaseCell.objectId return 0. So not use.
+        //setHasStableIds(true);
     }
 
     /**


### PR DESCRIPTION
修复由于设置了`setHasStableIds(true)`，但是getItemId却始终返回0，从而导致view重用显示错误。
#70 